### PR TITLE
Remove module boilerplate rules

### DIFF
--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -31,7 +31,7 @@ jobs:
             ${{ runner.os }}-
 
       - name: Install dependencies
-        run: npm ci
+        run: npm install
 
       - name: Run the linter
         run: npm run lint

--- a/base.js
+++ b/base.js
@@ -11,10 +11,6 @@ module.exports = {
 		"import/extensions": ["error", "never"],
 		"no-process-env": "error",
 		"no-process-exit": "error",
-		"no-restricted-syntax": ["error", {
-			message: "Don't declare enums",
-			selector: "TSEnumDeclaration",
-		}],
 		"no-sync": "warn",
 		"sort-imports-es6-autofix/sort-imports-es6": ["error", {
 			ignoreCase: true,

--- a/base.js
+++ b/base.js
@@ -8,7 +8,7 @@ module.exports = {
 		"sort-imports-es6-autofix",
 	],
 	rules: {
-		"import/extensions": ["error", "always", {ignorePackages: true}],
+		"import/extensions": ["error", "never"],
 		"no-process-env": "error",
 		"no-process-exit": "error",
 		"no-restricted-syntax": ["error", {


### PR DESCRIPTION
Since we're tabling the module switch I figure we should roll back some of the annoying stuff we've been doing in preparation for it. I'll be following this change with a PR in the api repo that gets rid of the import file extensions and changes the enums back.